### PR TITLE
Fix test packagin

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include test *.py
+recursive-include smoke *.py

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
     ],
     namespace_packages=['akanda'],
-    packages=find_packages(),
+    packages=find_packages(exclude=['test', 'smoke']),
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Ignore the test and smoke directories when looking
for python packages, to avoid having the files installed.
Include the directories in the source distribution, so
they are available to be run if the source package is
downloaded.

Change-Id: I31a11c8c7edc5a17cb050be3c045ef270eb57894
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
