### PR TITLE
Remove unused NVP_EXT_PATH variable

### DIFF
--- a/akanda/neutron/plugins/nsx_neutron_plugin.py
+++ b/akanda/neutron/plugins/nsx_neutron_plugin.py
@@ -15,7 +15,6 @@
 # under the License.
 
 import functools
-import os
 
 from sqlalchemy import exc as sql_exc
 
@@ -45,8 +44,6 @@ from akanda.neutron.plugins import floatingip
 
 LOG = logging.getLogger("NeutronPlugin")
 akanda.monkey_patch_ipv6_generator()
-
-NVP_EXT_PATH = os.path.join(os.path.dirname(__file__), 'extensions')
 
 
 def akanda_nvp_ipv6_port_security_wrapper(f):


### PR DESCRIPTION
The NVP_EXT_PATH variable has been renamed to NSX_EXT_PATH and
it's now imported directly from the vmware module in the **init**
of the NsxPluginV2 driver

Change-Id: I68661ec25bf730caf8a9910a26c82cb647ace750
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
