### PR TITLE
Fix routers sync issue

### DIFF
--- a/akanda/neutron/plugins/nsx_neutron_plugin.py
+++ b/akanda/neutron/plugins/nsx_neutron_plugin.py
@@ -197,7 +197,7 @@ class NsxPluginV2(floatingip.ExplicitFloatingIPAllocationMixin,
         #     self.nsx_sync_opts.min_chunk_size,
         #     self.nsx_sync_opts.max_random_sync_delay)
 
-        self._synchronizer = nsx_sync.NsxSynchronizer(
+        self._synchronizer = NsxSynchronizer(
             self, self.cluster,
             self.nsx_sync_opts.state_sync_interval,
             self.nsx_sync_opts.min_sync_req_delay,


### PR DESCRIPTION
The original NsxSynchronizer class was used instead of the our
subclass that overrides the methods for the routers sync to be
a noop.

Change-Id: I0291556e529d2364839b588b524d1bc6413241a8
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
