### PR TITLE
Fix nsx routers synchronization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     url='http://github.com/dreamhost/akanda',
     license='BSD',
     install_requires=[
+        'mock'
     ],
     namespace_packages=['akanda'],
     packages=find_packages(exclude=['test', 'smoke']),


### PR DESCRIPTION
Force the our custom nsx driver to not sync nsx routers with
neutron routers

Change-Id: Ia92386db9d33aa37f39e5b7e70f39df3e3c61b92
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
