### PR TITLE
Add synchronize_port implementation

### DIFF
--- a/akanda/neutron/plugins/nsx_neutron_plugin.py
+++ b/akanda/neutron/plugins/nsx_neutron_plugin.py
@@ -110,9 +110,11 @@ class AkandaNsxSynchronizer(nsx_sync.NsxSynchronizer):
     def synchronize_port(self, *args, **kwargs):
         LOG.debug("Attempting to call synchronize_port(%s)", args)
         try:
-            super(AkandaNsxSynchronizer, self).synchronize_port(*args, **kwargs)
-        except (DBError, StaleDataError) as db_exc:
-            LOG.exception("Encountered database error while updating the port.")
+            super(AkandaNsxSynchronizer,
+                  self).synchronize_port(*args, **kwargs)
+        except (sql_exc.DBError, sql_exc.StaleDataError):
+            LOG.exception("Encountered database error while updating the "
+                          "port.")
             pass
 
 


### PR DESCRIPTION
I added a `synchronize_port` implementation that wraps the base
class implementation and adds some extra logging to help track down
spurious, possible race-condition errors.
