### PR TITLE
change floatingip_subnet to ListOpt

### DIFF
--- a/akanda/neutron/plugins/floatingip.py
+++ b/akanda/neutron/plugins/floatingip.py
@@ -27,7 +27,7 @@ from oslo.config import cfg
 LOG = log.getLogger(__name__)
 
 explicit_floating_ip_opts = [
-    cfg.MultiStrOpt(
+    cfg.ListOpt(
         'floatingip_subnet',
         default=[],
         help='UUID(s) of subnet(s) from which floating IPs can be allocated',


### PR DESCRIPTION
For deployment, MultiStrOpt is a bit more difficult to deal with than
ListOpt so let's switch floatingip_subnet over to ListOpt while we still
can.